### PR TITLE
Add a test for (*Stream).removeReady()

### DIFF
--- a/exporter/otlpexporter/internal/arrow/common_test.go
+++ b/exporter/otlpexporter/internal/arrow/common_test.go
@@ -151,6 +151,8 @@ func (ctc *commonTestCase) returnNewStream(hs ...testChannel) func(context.Conte
 	}
 }
 
+// repeatedNewStream returns a stream configured with a new test
+// channel on every ArrowStream() request.
 func (ctc *commonTestCase) repeatedNewStream(nc func() testChannel) func(context.Context, ...grpc.CallOption) (
 	arrowpb.ArrowStreamService_ArrowStreamClient,
 	error,

--- a/exporter/otlpexporter/internal/arrow/common_test.go
+++ b/exporter/otlpexporter/internal/arrow/common_test.go
@@ -52,6 +52,11 @@ var (
 		NumStreams: 1,
 	}
 
+	twoStreamsSettings = Settings{
+		Enabled:    true,
+		NumStreams: 2,
+	}
+
 	twoTraces = testdata.GenerateTraces(2)
 )
 
@@ -68,15 +73,22 @@ type commonTestCase struct {
 	streamCall    *gomock.Call
 }
 
-func newTestTelemetry(t *testing.T) component.TelemetrySettings {
+type noisyTest bool
+
+const Noisy noisyTest = true
+const NotNoisy noisyTest = false
+
+func newTestTelemetry(t *testing.T, noisy noisyTest) component.TelemetrySettings {
 	telset := componenttest.NewNopTelemetrySettings()
-	telset.Logger = zaptest.NewLogger(t)
+	if !noisy {
+		telset.Logger = zaptest.NewLogger(t)
+	}
 	return telset
 }
 
-func newCommonTestCase(t *testing.T) *commonTestCase {
+func newCommonTestCase(t *testing.T, noisy noisyTest) *commonTestCase {
 	ctrl := gomock.NewController(t)
-	telset := newTestTelemetry(t)
+	telset := newTestTelemetry(t, noisy)
 
 	client := arrowCollectorMock.NewMockArrowStreamServiceClient(ctrl)
 
@@ -129,6 +141,25 @@ func (ctc *commonTestCase) returnNewStream(hs ...testChannel) func(context.Conte
 		if pos < len(hs) {
 			pos++
 		}
+		if err := h.onConnect(ctx); err != nil {
+			return nil, err
+		}
+		str := ctc.newMockStream(ctx)
+		str.sendCall.AnyTimes().DoAndReturn(h.onSend(ctx))
+		str.recvCall.AnyTimes().DoAndReturn(h.onRecv(ctx))
+		return str.streamClient, nil
+	}
+}
+
+func (ctc *commonTestCase) repeatedNewStream(nc func() testChannel) func(context.Context, ...grpc.CallOption) (
+	arrowpb.ArrowStreamService_ArrowStreamClient,
+	error,
+) {
+	return func(ctx context.Context, opts ...grpc.CallOption) (
+		arrowpb.ArrowStreamService_ArrowStreamClient,
+		error,
+	) {
+		h := nc()
 		if err := h.onConnect(ctx); err != nil {
 			return nil, err
 		}

--- a/exporter/otlpexporter/internal/arrow/exporter_test.go
+++ b/exporter/otlpexporter/internal/arrow/exporter_test.go
@@ -169,6 +169,8 @@ func TestArrowExporterStreamRace(t *testing.T) {
 
 	tc.streamCall.AnyTimes().DoAndReturn(tc.repeatedNewStream(func() testChannel {
 		tc := newUnresponsiveTestChannel()
+		// Immediately unblock to return the EOF to the stream
+		// receiver and shut down the stream.
 		go tc.unblock()
 		return tc
 	}))

--- a/exporter/otlpexporter/internal/arrow/exporter_test.go
+++ b/exporter/otlpexporter/internal/arrow/exporter_test.go
@@ -28,8 +28,8 @@ type exporterTestCase struct {
 	exporter *Exporter
 }
 
-func newExporterTestCase(t *testing.T, arrowset Settings) *exporterTestCase {
-	ctc := newCommonTestCase(t)
+func newExporterTestCase(t *testing.T, noisy noisyTest, arrowset Settings) *exporterTestCase {
+	ctc := newCommonTestCase(t, noisy)
 	exp := NewExporter(arrowset, ctc.telset, ctc.serviceClient, waitForReadyOption)
 
 	return &exporterTestCase{
@@ -40,7 +40,7 @@ func newExporterTestCase(t *testing.T, arrowset Settings) *exporterTestCase {
 
 // TestArrowExporterSuccess tests a single Send through a healthy channel.
 func TestArrowExporterSuccess(t *testing.T) {
-	tc := newExporterTestCase(t, singleStreamSettings)
+	tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
 	channel := newHealthyTestChannel(1)
 
 	tc.streamCall.Times(1).DoAndReturn(tc.returnNewStream(channel))
@@ -58,7 +58,7 @@ func TestArrowExporterSuccess(t *testing.T) {
 
 // TestArrowExporterTimeout tests that single slow Send leads to context canceled.
 func TestArrowExporterTimeout(t *testing.T) {
-	tc := newExporterTestCase(t, singleStreamSettings)
+	tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
 	channel := newUnresponsiveTestChannel()
 
 	tc.streamCall.Times(1).DoAndReturn(tc.returnNewStream(channel))
@@ -84,7 +84,7 @@ func TestArrowExporterTimeout(t *testing.T) {
 // (TODO in a precisely appropriate way) the connection is downgraded
 // without error.
 func TestArrowExporterDowngrade(t *testing.T) {
-	tc := newExporterTestCase(t, singleStreamSettings)
+	tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
 	channel := newArrowUnsupportedTestChannel()
 
 	tc.streamCall.AnyTimes().DoAndReturn(tc.returnNewStream(channel))
@@ -104,7 +104,7 @@ func TestArrowExporterDowngrade(t *testing.T) {
 // TestArrowExporterConnectTimeout tests that an error is returned to
 // the caller if the response does not arrive in time.
 func TestArrowExporterConnectTimeout(t *testing.T) {
-	tc := newExporterTestCase(t, singleStreamSettings)
+	tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
 	channel := newDisconnectedTestChannel()
 
 	tc.streamCall.AnyTimes().DoAndReturn(tc.returnNewStream(channel))
@@ -128,7 +128,7 @@ func TestArrowExporterConnectTimeout(t *testing.T) {
 // TestArrowExporterStreamFailure tests that a single stream failure
 // followed by a healthy stream.
 func TestArrowExporterStreamFailure(t *testing.T) {
-	tc := newExporterTestCase(t, singleStreamSettings)
+	tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
 	channel0 := newUnresponsiveTestChannel()
 	channel1 := newHealthyTestChannel(1)
 
@@ -155,6 +155,36 @@ func TestArrowExporterStreamFailure(t *testing.T) {
 		} else {
 			require.NoError(t, err)
 		}
+	}
+
+	require.NoError(t, tc.exporter.Shutdown(bg))
+}
+
+// TestArrowExporterStreamRace reproduces the situation needed for a
+// race between stream send and stream cancel, causing it to fully
+// exercise the removeReady() code path.
+func TestArrowExporterStreamRace(t *testing.T) {
+	// Two streams ensures every possibility.
+	tc := newExporterTestCase(t, Noisy, twoStreamsSettings)
+
+	tc.streamCall.AnyTimes().DoAndReturn(tc.repeatedNewStream(func() testChannel {
+		tc := newUnresponsiveTestChannel()
+		go tc.unblock()
+		return tc
+	}))
+
+	bg := context.Background()
+	require.NoError(t, tc.exporter.Start(bg))
+
+	for tries := 0; tries < 1000; tries++ {
+		stream, err := tc.exporter.GetStream(bg)
+		require.NotNil(t, stream)
+		require.NoError(t, err)
+
+		err = stream.SendAndWait(bg, twoTraces)
+
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrStreamRestarting))
 	}
 
 	require.NoError(t, tc.exporter.Shutdown(bg))

--- a/exporter/otlpexporter/internal/arrow/stream_test.go
+++ b/exporter/otlpexporter/internal/arrow/stream_test.go
@@ -55,7 +55,7 @@ func newStreamTestCase(t *testing.T) *streamTestCase {
 	bg, cancel := context.WithCancel(context.Background())
 	prio := newStreamPrioritizer(bg, aset)
 
-	ctc := newCommonTestCase(t)
+	ctc := newCommonTestCase(t, NotNoisy)
 	cts := ctc.newMockStream(bg)
 
 	stream := newStream(producer, prio, ctc.telset)


### PR DESCRIPTION

**Description:** 
Increases coverage of `removeReady()`. 

BEFORE:
```
ok  	go.opentelemetry.io/collector/exporter/otlpexporter/internal/arrow	1.329s	coverage: 86.4% of statements
```
AFTER
```
ok  	go.opentelemetry.io/collector/exporter/otlpexporter/internal/arrow	1.667s	coverage: 88.6% of statements
```

**Testing:** Verified that this hits 100% coverage in prioritizer.go.
