### PR TITLE
Add mock arrowRecord.Producer to arrow exporter test

### DIFF
--- a/exporter/otlpexporter/internal/arrow/common_test.go
+++ b/exporter/otlpexporter/internal/arrow/common_test.go
@@ -170,10 +170,10 @@ type healthyTestChannel struct {
 	recv chan *arrowpb.BatchStatus
 }
 
-func newHealthyTestChannel(sz int) *healthyTestChannel {
+func newHealthyTestChannel() *healthyTestChannel {
 	return &healthyTestChannel{
-		sent: make(chan *arrowpb.BatchArrowRecords, sz),
-		recv: make(chan *arrowpb.BatchStatus, sz),
+		sent: make(chan *arrowpb.BatchArrowRecords),
+		recv: make(chan *arrowpb.BatchStatus),
 	}
 }
 

--- a/exporter/otlpexporter/internal/arrow/exporter.go
+++ b/exporter/otlpexporter/internal/arrow/exporter.go
@@ -20,6 +20,7 @@ import (
 
 	arrowpb "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
 	arrowRecord "github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/collector/component"
@@ -157,8 +158,10 @@ func (e *Exporter) runArrowStream(ctx context.Context) {
 	stream := newStream(producer, e.ready, e.telemetry)
 
 	defer func() {
+		if err := producer.Close(); err != nil {
+			e.telemetry.Logger.Error("arrow producer close:", zap.Error(err))
+		}
 		e.wg.Done()
-		producer.Close()
 		e.returning <- stream
 	}()
 

--- a/exporter/otlpexporter/internal/arrow/exporter_test.go
+++ b/exporter/otlpexporter/internal/arrow/exporter_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	arrowRecord "github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
+	arrowRecordMock "github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +32,11 @@ type exporterTestCase struct {
 
 func newExporterTestCase(t *testing.T, noisy noisyTest, arrowset Settings) *exporterTestCase {
 	ctc := newCommonTestCase(t, noisy)
-	exp := NewExporter(arrowset, ctc.telset, ctc.serviceClient, nil)
+	exp := NewExporter(arrowset, func() arrowRecord.ProducerAPI {
+		prod := arrowRecordMock.NewMockProducerAPI(ctc.ctrl)
+		prod.EXPECT().Close().Times(1)
+		return prod
+	}, ctc.telset, ctc.serviceClient, nil)
 
 	return &exporterTestCase{
 		commonTestCase: ctc,

--- a/exporter/otlpexporter/internal/arrow/exporter_test.go
+++ b/exporter/otlpexporter/internal/arrow/exporter_test.go
@@ -26,6 +26,7 @@ import (
 	arrowRecordMock "github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record/mock"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -75,7 +76,7 @@ func statusOKFor(id string) *arrowpb.BatchStatus {
 func TestArrowExporterSuccess(t *testing.T) {
 	for _, inputData := range []interface{}{twoTraces, twoMetrics, twoLogs} {
 		tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
-		channel := newHealthyTestChannel(1)
+		channel := newHealthyTestChannel()
 
 		tc.streamCall.Times(1).DoAndReturn(tc.returnNewStream(channel))
 
@@ -192,7 +193,7 @@ func TestArrowExporterConnectTimeout(t *testing.T) {
 func TestArrowExporterStreamFailure(t *testing.T) {
 	tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
 	channel0 := newUnresponsiveTestChannel()
-	channel1 := newHealthyTestChannel(1)
+	channel1 := newHealthyTestChannel()
 
 	tc.streamCall.AnyTimes().DoAndReturn(tc.returnNewStream(channel0, channel1))
 
@@ -267,7 +268,7 @@ func TestArrowExporterStreamRace(t *testing.T) {
 // TestArrowExporterStreaming tests 10 sends in a row.
 func TestArrowExporterStreaming(t *testing.T) {
 	tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
-	channel := newHealthyTestChannel(1)
+	channel := newHealthyTestChannel()
 
 	tc.streamCall.AnyTimes().DoAndReturn(tc.returnNewStream(channel))
 

--- a/exporter/otlpexporter/internal/arrow/stream_test.go
+++ b/exporter/otlpexporter/internal/arrow/stream_test.go
@@ -129,7 +129,7 @@ func TestStreamEncodeError(t *testing.T) {
 	testErr := fmt.Errorf("test encode error")
 	tc.fromTracesCall.Times(1).Return(nil, testErr)
 
-	cleanup := tc.start(newHealthyTestChannel(1))
+	cleanup := tc.start(newHealthyTestChannel())
 	defer cleanup()
 
 	// sender should get a permanent testErr

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -23,6 +23,7 @@ import (
 
 	arrowPkg "github.com/apache/arrow/go/v10/arrow"
 	arrowpb "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
+	arrowRecord "github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
 	"go.uber.org/multierr"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
@@ -109,7 +110,9 @@ func (e *exporter) start(ctx context.Context, host component.Host) error {
 	if e.config.Arrow != nil && e.config.Arrow.Enabled {
 		ctx := e.enhanceContext(context.Background())
 
-		e.arrow = arrow.NewExporter(*e.config.Arrow, e.settings.TelemetrySettings, arrowpb.NewArrowStreamServiceClient(e.clientConn), e.callOptions)
+		e.arrow = arrow.NewExporter(*e.config.Arrow, func() arrowRecord.ProducerAPI {
+			return arrowRecord.NewProducer()
+		}, e.settings.TelemetrySettings, arrowpb.NewArrowStreamServiceClient(e.clientConn), e.callOptions)
 
 		if err := e.arrow.Start(ctx); err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/cenkalti/backoff/v4 v4.1.3
-	github.com/f5/otel-arrow-adapter v0.0.0-20221116234146-d8ecadf9751b
+	github.com/f5/otel-arrow-adapter v0.0.0-20221117192416-4be8d64bf483
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/f5/otel-arrow-adapter v0.0.0-20221116234146-d8ecadf9751b h1:tBjAqklK5qpwhB7hCpjjvkqxiM7khUpzTsl6eIaFK6Y=
-github.com/f5/otel-arrow-adapter v0.0.0-20221116234146-d8ecadf9751b/go.mod h1:gteT2yAp4EuA2lviis1z2qp1ETiQI7kBqQSN4ppFluk=
+github.com/f5/otel-arrow-adapter v0.0.0-20221117192416-4be8d64bf483 h1:/qSvgm9OdElmQjwY3IKy8GNeOmd41H149FRAUTSUv2E=
+github.com/f5/otel-arrow-adapter v0.0.0-20221117192416-4be8d64bf483/go.mod h1:gteT2yAp4EuA2lviis1z2qp1ETiQI7kBqQSN4ppFluk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=


### PR DESCRIPTION
**Description:** 
The mock Producer calls through to a real Producer, asserts Close is called exactly once.
Also improves test synchronization and data correctness for `*healthyTestChannel`-based tests. 
Adds one new test that sends 10 trace batches.

Note this sets up the necessary support for a follow-on test, which will cover encoder failures and non-OK batch status.