### PR TITLE
Test exporter OTLP-Arrow stream StatusCode_ERROR code paths

### DIFF
--- a/exporter/otlpexporter/internal/arrow/common_test.go
+++ b/exporter/otlpexporter/internal/arrow/common_test.go
@@ -299,45 +299,6 @@ func (tc *disconnectedTestChannel) onRecv(ctx context.Context) func() (*arrowpb.
 	}
 }
 
-// unknownBatchIDTestChannel returns an unknown Batch ID
-type unknownBatchIDTestChannel struct {
-	release chan struct{}
-}
-
-func newUnknownBatchIDTestChannel() *unknownBatchIDTestChannel {
-	return &unknownBatchIDTestChannel{
-		release: make(chan struct{}),
-	}
-}
-
-func (tc *unknownBatchIDTestChannel) onConnect(ctx context.Context) error {
-	return nil
-}
-
-func (tc *unknownBatchIDTestChannel) onSend(ctx context.Context) func(*arrowpb.BatchArrowRecords) error {
-	return func(*arrowpb.BatchArrowRecords) error {
-		return nil
-	}
-}
-
-func (tc *unknownBatchIDTestChannel) unblock() {
-	close(tc.release)
-}
-
-func (tc *unknownBatchIDTestChannel) onRecv(ctx context.Context) func() (*arrowpb.BatchStatus, error) {
-	return func() (*arrowpb.BatchStatus, error) {
-		<-tc.release
-		return &arrowpb.BatchStatus{
-			Statuses: []*arrowpb.StatusMessage{
-				{
-					BatchId:    "unknown",
-					StatusCode: arrowpb.StatusCode_OK,
-				},
-			},
-		}, nil
-	}
-}
-
 // sendErrorTestChannel returns an error in Send()
 type sendErrorTestChannel struct {
 	release chan struct{}

--- a/exporter/otlpexporter/internal/arrow/exporter_test.go
+++ b/exporter/otlpexporter/internal/arrow/exporter_test.go
@@ -72,6 +72,45 @@ func statusOKFor(id string) *arrowpb.BatchStatus {
 	}
 }
 
+func statusUnavailableFor(id string) *arrowpb.BatchStatus {
+	return &arrowpb.BatchStatus{
+		Statuses: []*arrowpb.StatusMessage{
+			{
+				BatchId:      id,
+				StatusCode:   arrowpb.StatusCode_ERROR,
+				ErrorCode:    arrowpb.ErrorCode_UNAVAILABLE,
+				ErrorMessage: "test unavailable",
+			},
+		},
+	}
+}
+
+func statusInvalidFor(id string) *arrowpb.BatchStatus {
+	return &arrowpb.BatchStatus{
+		Statuses: []*arrowpb.StatusMessage{
+			{
+				BatchId:      id,
+				StatusCode:   arrowpb.StatusCode_ERROR,
+				ErrorCode:    arrowpb.ErrorCode_INVALID_ARGUMENT,
+				ErrorMessage: "test invalid",
+			},
+		},
+	}
+}
+
+func statusUnrecognizedFor(id string) *arrowpb.BatchStatus {
+	return &arrowpb.BatchStatus{
+		Statuses: []*arrowpb.StatusMessage{
+			{
+				BatchId:      id,
+				StatusCode:   arrowpb.StatusCode_ERROR,
+				ErrorCode:    1 << 20,
+				ErrorMessage: "test unrecognized",
+			},
+		},
+	}
+}
+
 // TestArrowExporterSuccess tests a single Send through a healthy channel.
 func TestArrowExporterSuccess(t *testing.T) {
 	for _, inputData := range []interface{}{twoTraces, twoMetrics, twoLogs} {


### PR DESCRIPTION
**Description:** 
Add tests for several StatusCode_ERROR code paths (two normal, one unrecognized).

Part of #22.