### PR TITLE
Test the top-level OTLP/Arrow exporter

### DIFF
--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -86,8 +86,8 @@ func TestUnmarshalConfig(t *testing.T) {
 				Auth:            &configauth.Authentication{AuthenticatorID: config.NewComponentID("nop")},
 			},
 			Arrow: &arrow.Settings{
-				Enabled:    false,
-				NumStreams: 1,
+				Enabled:    true,
+				NumStreams: 2,
 			},
 		}, cfg)
 }

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/config/configtest"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/otlpexporter/internal/arrow"
 	"go.opentelemetry.io/collector/internal/testutil"
 )
 
@@ -44,6 +45,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, ocfg.QueueSettings, exporterhelper.NewDefaultQueueSettings())
 	assert.Equal(t, ocfg.TimeoutSettings, exporterhelper.NewDefaultTimeoutSettings())
 	assert.Equal(t, ocfg.Compression, configcompression.Gzip)
+	assert.Equal(t, ocfg.Arrow, &arrow.Settings{Enabled: false, NumStreams: 1})
 }
 
 func TestCreateMetricsExporter(t *testing.T) {
@@ -226,6 +228,20 @@ func TestCreateLogsExporter(t *testing.T) {
 
 	set := componenttest.NewNopExporterCreateSettings()
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
+	require.Nil(t, err)
+	require.NotNil(t, oexp)
+}
+
+func TestCreateArrowTracesExporter(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.Arrow = &arrow.Settings{
+		Enabled:    true,
+		NumStreams: 1,
+	}
+	set := componenttest.NewNopExporterCreateSettings()
+	oexp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
 }

--- a/exporter/otlpexporter/internal/arrow/common_test.go
+++ b/exporter/otlpexporter/internal/arrow/common_test.go
@@ -23,28 +23,23 @@ import (
 	arrowpb "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
 	arrowCollectorMock "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1/mock"
 	"github.com/golang/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/internal/testdata"
 )
 
-// TODO: More tests requested in PR12:
-// Case of a very large protobuf message whose objective would be to
-// crash the collector (maybe this test is already done at the
-// collector level in a more general way).
-
 var (
 	singleStreamSettings = Settings{
 		Enabled:    true,
 		NumStreams: 1,
-	}
-
-	twoStreamsSettings = Settings{
-		Enabled:    true,
-		NumStreams: 2,
 	}
 
 	twoTraces  = testdata.GenerateTraces(2)
@@ -61,6 +56,7 @@ type testChannel interface {
 type commonTestCase struct {
 	ctrl          *gomock.Controller
 	telset        component.TelemetrySettings
+	observedLogs  *observer.ObservedLogs
 	serviceClient arrowpb.ArrowStreamServiceClient
 	streamCall    *gomock.Call
 }
@@ -70,17 +66,21 @@ type noisyTest bool
 const Noisy noisyTest = true
 const NotNoisy noisyTest = false
 
-func newTestTelemetry(t *testing.T, noisy noisyTest) component.TelemetrySettings {
+func newTestTelemetry(t *testing.T, noisy noisyTest) (_ component.TelemetrySettings, obslogs *observer.ObservedLogs) {
 	telset := componenttest.NewNopTelemetrySettings()
 	if !noisy {
-		telset.Logger = zaptest.NewLogger(t)
+		var core zapcore.Core
+		core, obslogs = observer.New(zapcore.DebugLevel)
+
+		telset.Logger = zap.New(zapcore.NewTee(core, zaptest.NewLogger(t).Core()))
+
 	}
-	return telset
+	return telset, obslogs
 }
 
 func newCommonTestCase(t *testing.T, noisy noisyTest) *commonTestCase {
 	ctrl := gomock.NewController(t)
-	telset := newTestTelemetry(t, noisy)
+	telset, obslogs := newTestTelemetry(t, noisy)
 
 	client := arrowCollectorMock.NewMockArrowStreamServiceClient(ctrl)
 
@@ -91,6 +91,7 @@ func newCommonTestCase(t *testing.T, noisy noisyTest) *commonTestCase {
 	return &commonTestCase{
 		ctrl:          ctrl,
 		telset:        telset,
+		observedLogs:  obslogs,
 		serviceClient: client,
 		streamCall:    streamCall,
 	}
@@ -249,8 +250,8 @@ func (tc *unresponsiveTestChannel) unblock() {
 	close(tc.ch)
 }
 
-// unsupportedTestChannel does not accept the connection.
-// TODO: Make this match the behavior of the gRPC server for an unrecognized request.
+// unsupportedTestChannel mimics gRPC's behavior when there is no
+// arrow stream service registered with the server.
 type arrowUnsupportedTestChannel struct {
 }
 
@@ -259,18 +260,23 @@ func newArrowUnsupportedTestChannel() *arrowUnsupportedTestChannel {
 }
 
 func (tc *arrowUnsupportedTestChannel) onConnect(_ context.Context) error {
-	return fmt.Errorf("connection failed")
+	// Note: this matches gRPC's apparent behavior. the stream
+	// connection succeeds and the unsupported code is returned to
+	// the Recv() call.
+	return nil
 }
 
 func (tc *arrowUnsupportedTestChannel) onSend(ctx context.Context) func(*arrowpb.BatchArrowRecords) error {
 	return func(req *arrowpb.BatchArrowRecords) error {
-		panic("unreachable")
+		<-ctx.Done()
+		return ctx.Err()
 	}
 }
 
 func (tc *arrowUnsupportedTestChannel) onRecv(ctx context.Context) func() (*arrowpb.BatchStatus, error) {
 	return func() (*arrowpb.BatchStatus, error) {
-		panic("unreachable")
+		err := status.Error(codes.Unimplemented, "arrow will not be served")
+		return &arrowpb.BatchStatus{}, err
 	}
 }
 
@@ -328,5 +334,29 @@ func (tc *sendErrorTestChannel) onRecv(ctx context.Context) func() (*arrowpb.Bat
 	return func() (*arrowpb.BatchStatus, error) {
 		<-tc.release
 		return &arrowpb.BatchStatus{}, io.EOF
+	}
+}
+
+// connectErrorTestChannel returns an error from the ArrowStream() call
+type connectErrorTestChannel struct {
+}
+
+func newConnectErrorTestChannel() *connectErrorTestChannel {
+	return &connectErrorTestChannel{}
+}
+
+func (tc *connectErrorTestChannel) onConnect(ctx context.Context) error {
+	return fmt.Errorf("test connect error")
+}
+
+func (tc *connectErrorTestChannel) onSend(ctx context.Context) func(*arrowpb.BatchArrowRecords) error {
+	return func(*arrowpb.BatchArrowRecords) error {
+		panic("not reached")
+	}
+}
+
+func (tc *connectErrorTestChannel) onRecv(ctx context.Context) func() (*arrowpb.BatchStatus, error) {
+	return func() (*arrowpb.BatchStatus, error) {
+		panic("not reached")
 	}
 }

--- a/exporter/otlpexporter/internal/arrow/common_test.go
+++ b/exporter/otlpexporter/internal/arrow/common_test.go
@@ -66,15 +66,13 @@ type noisyTest bool
 const Noisy noisyTest = true
 const NotNoisy noisyTest = false
 
-func newTestTelemetry(t *testing.T, noisy noisyTest) (_ component.TelemetrySettings, obslogs *observer.ObservedLogs) {
+func newTestTelemetry(t *testing.T, noisy noisyTest) (component.TelemetrySettings, *observer.ObservedLogs) {
 	telset := componenttest.NewNopTelemetrySettings()
-	if !noisy {
-		var core zapcore.Core
-		core, obslogs = observer.New(zapcore.DebugLevel)
-
-		telset.Logger = zap.New(zapcore.NewTee(core, zaptest.NewLogger(t).Core()))
-
+	if noisy {
+		return telset, nil
 	}
+	core, obslogs := observer.New(zapcore.DebugLevel)
+	telset.Logger = zap.New(zapcore.NewTee(core, zaptest.NewLogger(t).Core()))
 	return telset, obslogs
 }
 

--- a/exporter/otlpexporter/internal/arrow/exporter_test.go
+++ b/exporter/otlpexporter/internal/arrow/exporter_test.go
@@ -25,7 +25,9 @@ import (
 	arrowRecord "github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
 	arrowRecordMock "github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record/mock"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -122,9 +124,6 @@ func TestArrowExporterSuccess(t *testing.T) {
 		ctx := context.Background()
 		require.NoError(t, tc.exporter.Start(ctx))
 
-		consumer, err := tc.exporter.GetStream(ctx)
-		require.NoError(t, err)
-
 		var wg sync.WaitGroup
 		var outputData *arrowpb.BatchArrowRecords
 		wg.Add(1)
@@ -134,7 +133,9 @@ func TestArrowExporterSuccess(t *testing.T) {
 			channel.recv <- statusOKFor(outputData.BatchId)
 		}()
 
-		require.NoError(t, consumer.SendAndWait(ctx, inputData))
+		sent, err := tc.exporter.SendAndWait(ctx, inputData)
+		require.NoError(t, err)
+		require.True(t, sent)
 
 		wg.Wait()
 
@@ -168,22 +169,39 @@ func TestArrowExporterTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, tc.exporter.Start(ctx))
 
-	consumer, err := tc.exporter.GetStream(ctx)
-	require.NoError(t, err)
-
 	go func() {
 		time.Sleep(200 * time.Millisecond)
 		cancel()
 	}()
-	err = consumer.SendAndWait(ctx, twoTraces)
+	_, err := tc.exporter.SendAndWait(ctx, twoTraces)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.Canceled))
 
 	require.NoError(t, tc.exporter.Shutdown(ctx))
 }
 
-// TestArrowExporterDowngrade tests that if the connetions fail fast
-// (TODO in a precisely appropriate way) the connection is downgraded
+// TestConnectError tests that if the connetions fail fast the
+// stream object for some reason is nil.  This causes downgrade.
+func TestArrowExporterStreamConnectError(t *testing.T) {
+	tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
+	channel := newConnectErrorTestChannel()
+
+	tc.streamCall.AnyTimes().DoAndReturn(tc.returnNewStream(channel))
+
+	bg := context.Background()
+	require.NoError(t, tc.exporter.Start(bg))
+
+	sent, err := tc.exporter.SendAndWait(bg, twoTraces)
+	require.False(t, sent)
+	require.NoError(t, err)
+
+	require.NoError(t, tc.exporter.Shutdown(bg))
+
+	require.Equal(t, tc.observedLogs.All()[0].Message, "cannot start arrow stream")
+}
+
+// TestArrowExporterDowngrade tests that if the Recv() returns an
+// Unimplemented code (as gRPC does) that the connection is downgraded
 // without error.
 func TestArrowExporterDowngrade(t *testing.T) {
 	tc := newExporterTestCase(t, NotNoisy, singleStreamSettings)
@@ -194,13 +212,14 @@ func TestArrowExporterDowngrade(t *testing.T) {
 	bg := context.Background()
 	require.NoError(t, tc.exporter.Start(bg))
 
-	stream, err := tc.exporter.GetStream(bg)
-	require.Nil(t, stream)
+	sent, err := tc.exporter.SendAndWait(bg, twoTraces)
+	require.False(t, sent)
 	require.NoError(t, err)
 
-	// TODO: test the logger was used to report "downgrading"
-
 	require.NoError(t, tc.exporter.Shutdown(bg))
+
+	require.Equal(t, tc.observedLogs.All()[0].Message, "arrow is not supported")
+	require.Contains(t, tc.observedLogs.All()[1].Message, "downgrading")
 }
 
 // TestArrowExporterConnectTimeout tests that an error is returned to
@@ -219,8 +238,7 @@ func TestArrowExporterConnectTimeout(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 		cancel()
 	}()
-	stream, err := tc.exporter.GetStream(ctx)
-	require.Nil(t, stream)
+	_, err := tc.exporter.SendAndWait(ctx, twoTraces)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.Canceled))
 
@@ -253,20 +271,10 @@ func TestArrowExporterStreamFailure(t *testing.T) {
 		channel1.recv <- statusOKFor(outputData.BatchId)
 	}()
 
-	for times := 0; times < 2; times++ {
-		stream, err := tc.exporter.GetStream(bg)
-		require.NotNil(t, stream)
-		require.NoError(t, err)
+	sent, err := tc.exporter.SendAndWait(bg, twoTraces)
+	require.NoError(t, err)
+	require.True(t, sent)
 
-		err = stream.SendAndWait(bg, twoTraces)
-
-		if times == 0 {
-			require.Error(t, err)
-			require.True(t, errors.Is(err, ErrStreamRestarting))
-		} else {
-			require.NoError(t, err)
-		}
-	}
 	wg.Wait()
 
 	require.NoError(t, tc.exporter.Shutdown(bg))
@@ -277,30 +285,52 @@ func TestArrowExporterStreamFailure(t *testing.T) {
 // exercise the removeReady() code path.
 func TestArrowExporterStreamRace(t *testing.T) {
 	// Two streams ensures every possibility.
-	tc := newExporterTestCase(t, Noisy, twoStreamsSettings)
+	tc := newExporterTestCase(t, Noisy, Settings{
+		Enabled: true,
+
+		// This creates the conditions likely to produce a
+		// stream race in prioritizer.go.
+		NumStreams: 20,
+	})
+
+	var tries atomic.Int32
 
 	tc.streamCall.AnyTimes().DoAndReturn(tc.repeatedNewStream(func() testChannel {
 		tc := newUnresponsiveTestChannel()
 		// Immediately unblock to return the EOF to the stream
 		// receiver and shut down the stream.
 		go tc.unblock()
+		tries.Add(1)
 		return tc
 	}))
+
+	var wg sync.WaitGroup
 
 	bg := context.Background()
 	require.NoError(t, tc.exporter.Start(bg))
 
-	for tries := 0; tries < 1000; tries++ {
-		stream, err := tc.exporter.GetStream(bg)
-		require.NotNil(t, stream)
-		require.NoError(t, err)
+	callctx, cancel := context.WithCancel(bg)
 
-		err = stream.SendAndWait(bg, twoTraces)
-
-		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrStreamRestarting))
+	// One goroutine will cancel the context in a while
+	// Goroutines will wait for the timeout.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// This blocks until the cancelation.
+			_, err := tc.exporter.SendAndWait(callctx, twoTraces)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, context.Canceled))
+		}()
 	}
 
+	// Wait until 1000 streams have started.
+	assert.Eventually(t, func() bool {
+		return tries.Load() >= 1000
+	}, 10*time.Second, 5*time.Millisecond)
+
+	cancel()
+	wg.Wait()
 	require.NoError(t, tc.exporter.Shutdown(bg))
 }
 
@@ -332,15 +362,14 @@ func TestArrowExporterStreaming(t *testing.T) {
 	}()
 
 	for times := 0; times < 10; times++ {
-		stream, err := tc.exporter.GetStream(bg)
-		require.NotNil(t, stream)
-		require.NoError(t, err)
-
 		input := testdata.GenerateTraces(2)
-		expectOutput = append(expectOutput, input)
+		ctx := context.Background()
 
-		err = stream.SendAndWait(bg, input)
+		sent, err := tc.exporter.SendAndWait(ctx, input)
 		require.NoError(t, err)
+		require.True(t, sent)
+
+		expectOutput = append(expectOutput, input)
 	}
 	// Stop the test conduit started above.  If the sender were
 	// still sending, it would panic on a closed channel.

--- a/exporter/otlpexporter/internal/arrow/prioritizer.go
+++ b/exporter/otlpexporter/internal/arrow/prioritizer.go
@@ -81,8 +81,9 @@ func (sp *streamPrioritizer) removeReady(stream *Stream) {
 			sp.channel <- alternate
 		case wri := <-stream.toWrite:
 			// A consumer got us first, means this stream has been removed
-			// from the ready queue.  Note: exporterhelper will retry.
-			// TODO: Would it be better to handle retry in this directly?
+			// from the ready queue.
+			//
+			// Note: the top-level OTLP exporter will retry.
 			wri.errCh <- ErrStreamRestarting
 			return
 		}

--- a/exporter/otlpexporter/internal/arrow/stream.go
+++ b/exporter/otlpexporter/internal/arrow/stream.go
@@ -124,7 +124,7 @@ func (s *Stream) run(bgctx context.Context, client arrowpb.ArrowStreamServiceCli
 	}
 	// Setting .client != nil indicates that the endpoint was valid,
 	// streaming may start.  When this stream finishes, it will be
-	// restartd.
+	// restarted.
 	s.client = sc
 
 	// ww is used to wait for the writer.  Since we wait for the writer,
@@ -163,6 +163,7 @@ func (s *Stream) run(bgctx context.Context, client arrowpb.ArrowStreamServiceCli
 			s.client = nil
 			s.telemetry.Logger.Info("arrow is not supported", zap.Error(err))
 		} else if !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
+			// TODO: Should we add debug-level logs for EOF and Canceled?
 			s.telemetry.Logger.Error("arrow recv", zap.Error(err))
 		}
 	}
@@ -216,6 +217,7 @@ func (s *Stream) write(ctx context.Context) {
 
 		if err := s.client.Send(batch); err != nil {
 			// The error will be sent to errCh during cleanup for this stream.
+			// TODO: Should we add debug-level logs for EOF and Canceled?
 			if !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
 				s.telemetry.Logger.Error("arrow send", zap.Error(err))
 			}

--- a/exporter/otlpexporter/internal/arrow/stream.go
+++ b/exporter/otlpexporter/internal/arrow/stream.go
@@ -16,7 +16,9 @@ package arrow // import "go.opentelemetry.io/collector/exporter/otlpexporter/int
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"sync"
 
 	arrowpb "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
@@ -24,6 +26,8 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -100,18 +104,27 @@ func (s *Stream) run(bgctx context.Context, client arrowpb.ArrowStreamServiceCli
 
 	sc, err := client.ArrowStream(ctx, grpcOptions...)
 	if err != nil {
-		// TODO: only when this is a permanent (e.g., "no such
-		// method") error, downgrade to standard OTLP.
 		// Returning with stream.client == nil signals the
 		// lack of an Arrow stream endpoint.  When all the
 		// streams return with .client == nil, the ready
 		// channel will be closed.
-		s.telemetry.Logger.Error("cannot start event stream", zap.Error(err))
+		//
+		// Note: These are gRPC server internal errors and
+		// will cause downgrade to standard OTLP.  These
+		// cannot be simulated by connecting to a gRPC server
+		// that does not support the ArrowStream service, with
+		// or without the WaitForReady flag set.  In a real
+		// gRPC server the first Unimplemented code is
+		// generally delivered to the Recv() call below, so
+		// this code path is not taken for an ordinary downgrade.
+		//
+		// TODO: a more graceful recovery strategy?
+		s.telemetry.Logger.Error("cannot start arrow stream", zap.Error(err))
 		return
 	}
 	// Setting .client != nil indicates that the endpoint was valid,
 	// streaming may start.  When this stream finishes, it will be
-	// restarted.
+	// restartd.
 	s.client = sc
 
 	// ww is used to wait for the writer.  Since we wait for the writer,
@@ -125,18 +138,39 @@ func (s *Stream) run(bgctx context.Context, client arrowpb.ArrowStreamServiceCli
 		s.write(ctx)
 	}()
 
-	if err := s.read(ctx); err != nil {
-		s.telemetry.Logger.Error("arrow recv", zap.Error(err))
-	}
+	// the result from read() is processed after cancel and wait,
+	// so we can set s.client = nil in case of a delayed Unimplemented.
+	err = s.read(ctx)
+
 	// Wait for the writer to ensure that all waiters are known.
 	cancel()
 	ww.Wait()
 
+	if err != nil {
+		// This branch is reached with an unimplemented status
+		// with or without the WaitForReady flag.
+		if status, ok := status.FromError(err); ok && status.Code() == codes.Unimplemented {
+			// This (client == nil) signals the controller
+			// to downgrade when all streams have returned
+			// in that status.
+			//
+			// TODO: Note there are partial failure modes
+			// that will continue to function in a
+			// degraded mode, such as when half of the
+			// streams are successful and half of streams
+			// take this return path.  Design a graceful
+			// recovery mechanism?
+			s.client = nil
+			s.telemetry.Logger.Info("arrow is not supported", zap.Error(err))
+		} else if !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
+			s.telemetry.Logger.Error("arrow recv", zap.Error(err))
+		}
+	}
+
 	// The reader and writer have both finished; respond to any
 	// outstanding waiters.
 	for _, ch := range s.waiters {
-		// Note: exporterhelper will retry.
-		// TODO: Would it be better to handle retry in this directly?
+		// Note: the top-level OTLP exporter will retry.
 		ch <- ErrStreamRestarting
 	}
 }
@@ -182,7 +216,9 @@ func (s *Stream) write(ctx context.Context) {
 
 		if err := s.client.Send(batch); err != nil {
 			// The error will be sent to errCh during cleanup for this stream.
-			s.telemetry.Logger.Error("arrow send", zap.Error(err))
+			if !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
+				s.telemetry.Logger.Error("arrow send", zap.Error(err))
+			}
 			return
 		}
 	}

--- a/exporter/otlpexporter/internal/arrow/stream_test.go
+++ b/exporter/otlpexporter/internal/arrow/stream_test.go
@@ -250,6 +250,7 @@ func TestStreamUnsupported(t *testing.T) {
 
 	tc.waitForShutdown()
 
+	require.Less(t, 0, len(tc.observedLogs.All()), "should have at least one log: %v", tc.observedLogs.All())
 	require.Equal(t, tc.observedLogs.All()[0].Message, "arrow is not supported")
 }
 

--- a/exporter/otlpexporter/testdata/config.yaml
+++ b/exporter/otlpexporter/testdata/config.yaml
@@ -23,3 +23,6 @@ keepalive:
   timeout: 30s
   permit_without_stream: true
 balancer_name: "round_robin"
+arrow:
+  num_streams: 2
+  enabled: true


### PR DESCRIPTION
Test the top-level exporter, including success and downgrade cases.

Improvements in internal/arrow:
- Exporter SendAndWait() method handles internal retry for arrow stream restart.
- Test specific gRPC behavior when arrow service is not registered.
- Remove a few TODOs as they are now resolved.

Fixes #22.