### PR TITLE
Test the top-level OTLP/Arrow receiver

### DIFF
--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -140,6 +140,9 @@ func TestUnmarshalConfig(t *testing.T) {
 						MaxAge:         7200,
 					},
 				},
+				Arrow: &ArrowSettings{
+					Enabled: true,
+				},
 			},
 		}, cfg)
 
@@ -165,6 +168,9 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 				HTTP: &confighttp.HTTPServerSettings{
 					Endpoint: "/tmp/http_otlp.sock",
 					// Transport: "unix",
+				},
+				Arrow: &ArrowSettings{
+					Enabled: false,
 				},
 			},
 		}, cfg)
@@ -193,6 +199,15 @@ func TestUnmarshalConfigEmptyProtocols(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	assert.NoError(t, config.UnmarshalReceiver(cm, cfg))
 	assert.EqualError(t, cfg.Validate(), "must specify at least one protocol when using the OTLP receiver")
+}
+
+func TestUnmarshalConfigArrowWithoutGRPC(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "arrow_without_grpc.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	assert.NoError(t, config.UnmarshalReceiver(cm, cfg))
+	assert.EqualError(t, cfg.Validate(), "must specify at gRPC protocol when using the OTLP+Arrow receiver")
 }
 
 func TestUnmarshalConfigEmpty(t *testing.T) {

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -59,6 +59,9 @@ func createDefaultConfig() config.Receiver {
 			HTTP: &confighttp.HTTPServerSettings{
 				Endpoint: defaultHTTPEndpoint,
 			},
+			Arrow: &ArrowSettings{
+				Enabled: false,
+			},
 		},
 	}
 }

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -44,6 +44,7 @@ func TestCreateReceiver(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPC.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.HTTP.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.Arrow.Enabled = true
 
 	creationSet := componenttest.NewNopReceiverCreateSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())

--- a/receiver/otlpreceiver/testdata/arrow_without_grpc.yaml
+++ b/receiver/otlpreceiver/testdata/arrow_without_grpc.yaml
@@ -1,0 +1,5 @@
+# The following entry initializes the an OTLP receiver without gRPC but with arrow.
+protocols:
+  http:
+  arrow:
+    enabled: true

--- a/receiver/otlpreceiver/testdata/config.yaml
+++ b/receiver/otlpreceiver/testdata/config.yaml
@@ -39,3 +39,6 @@ protocols:
         - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
         - https://test.com # Fully qualified domain name. Allows https://test.com only.
       max_age: 7200
+  # Arrow enables receiving OTLP+Arrow streaming
+  arrow:
+    enabled: true


### PR DESCRIPTION
One new test passes traces through the OTLP Receiver with Arrow enabled. 
Adds to existing tests for config & factory validation.

Fixes #21.