### PR TITLE
Add support for disabling the downgrade feature

### DIFF
--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -36,8 +36,9 @@ type Config struct {
 // ArrowSettings includes whether Arrow is enabled and the number of
 // concurrent Arrow streams.
 type ArrowSettings struct {
-	Enabled    bool `mapstructure:"enabled"`
-	NumStreams int  `mapstructure:"num_streams"`
+	Enabled          bool `mapstructure:"enabled"`
+	NumStreams       int  `mapstructure:"num_streams"`
+	DisableDowngrade bool `mapstructure:"disable_downgrade"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/exporter/otlpexporter/internal/arrow/exporter.go
+++ b/exporter/otlpexporter/internal/arrow/exporter.go
@@ -34,7 +34,7 @@ type Exporter struct {
 	// numStreams is the number of streams that will be used.
 	numStreams int
 
-	// disableDowngrade prevents downgrade from occuring, supports
+	// disableDowngrade prevents downgrade from occurring, supports
 	// forcing Arrow transport.
 	disableDowngrade bool
 

--- a/exporter/otlpexporter/internal/arrow/exporter.go
+++ b/exporter/otlpexporter/internal/arrow/exporter.go
@@ -34,6 +34,10 @@ type Exporter struct {
 	// numStreams is the number of streams that will be used.
 	numStreams int
 
+	// disableDowngrade prevents downgrade from occuring, supports
+	// forcing Arrow transport.
+	disableDowngrade bool
+
 	// telemetry includes logger, tracer, meter.
 	telemetry component.TelemetrySettings
 
@@ -77,6 +81,7 @@ type Exporter struct {
 // NewExporter configures a new Exporter.
 func NewExporter(
 	numStreams int,
+	disableDowngrade bool,
 	telemetry component.TelemetrySettings,
 	grpcOptions []grpc.CallOption,
 	newProducer func() arrowRecord.ProducerAPI,
@@ -85,6 +90,7 @@ func NewExporter(
 ) *Exporter {
 	return &Exporter{
 		numStreams:        numStreams,
+		disableDowngrade:  disableDowngrade,
 		telemetry:         telemetry,
 		grpcOptions:       grpcOptions,
 		newProducer:       newProducer,
@@ -127,7 +133,7 @@ func (e *Exporter) runStreamController(bgctx context.Context) {
 	for {
 		select {
 		case stream := <-e.returning:
-			if stream.client != nil {
+			if stream.client != nil || e.disableDowngrade {
 				// The stream closed or broken.  Restart it.
 				e.wg.Add(1)
 				go e.runArrowStream(bgctx)

--- a/exporter/otlpexporter/internal/arrow/exporter_test.go
+++ b/exporter/otlpexporter/internal/arrow/exporter_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"golang.org/x/net/http2/hpack"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
 	"go.opentelemetry.io/collector/internal/testdata"
@@ -65,12 +66,16 @@ type exporterTestCase struct {
 }
 
 func newSingleStreamTestCase(t *testing.T) *exporterTestCase {
-	return newExporterTestCaseCommon(t, NotNoisy, 1, nil)
+	return newExporterTestCaseCommon(t, NotNoisy, 1, false, nil)
+}
+
+func newSingleStreamDowngradeDisabledTestCase(t *testing.T) *exporterTestCase {
+	return newExporterTestCaseCommon(t, NotNoisy, 1, true, nil)
 }
 
 func newSingleStreamMetadataTestCase(t *testing.T) *exporterTestCase {
 	var count int
-	return newExporterTestCaseCommon(t, NotNoisy, 1, func(ctx context.Context) (map[string]string, error) {
+	return newExporterTestCaseCommon(t, NotNoisy, 1, false, func(ctx context.Context) (map[string]string, error) {
 		defer func() { count++ }()
 		if count%2 == 0 {
 			return nil, nil
@@ -83,10 +88,10 @@ func newSingleStreamMetadataTestCase(t *testing.T) *exporterTestCase {
 }
 
 func newExporterNoisyTestCase(t *testing.T, numStreams int) *exporterTestCase {
-	return newExporterTestCaseCommon(t, Noisy, numStreams, nil)
+	return newExporterTestCaseCommon(t, Noisy, numStreams, false, nil)
 }
 
-func newExporterTestCaseCommon(t *testing.T, noisy noisyTest, numStreams int, metadataFunc func(ctx context.Context) (map[string]string, error)) *exporterTestCase {
+func newExporterTestCaseCommon(t *testing.T, noisy noisyTest, numStreams int, disableDowngrade bool, metadataFunc func(ctx context.Context) (map[string]string, error)) *exporterTestCase {
 	ctc := newCommonTestCase(t, noisy)
 
 	if metadataFunc == nil {
@@ -97,7 +102,7 @@ func newExporterTestCaseCommon(t *testing.T, noisy noisyTest, numStreams int, me
 		})
 	}
 
-	exp := NewExporter(numStreams, ctc.telset, nil, func() arrowRecord.ProducerAPI {
+	exp := NewExporter(numStreams, disableDowngrade, ctc.telset, nil, func() arrowRecord.ProducerAPI {
 		// Mock the close function, use a real producer for testing dataflow.
 		prod := arrowRecordMock.NewMockProducerAPI(ctc.ctrl)
 		real := arrowRecord.NewProducer()
@@ -292,6 +297,52 @@ func TestArrowExporterDowngrade(t *testing.T) {
 	require.Less(t, 1, len(tc.observedLogs.All()), "should have at least two logs: %v", tc.observedLogs.All())
 	require.Equal(t, tc.observedLogs.All()[0].Message, "arrow is not supported")
 	require.Contains(t, tc.observedLogs.All()[1].Message, "downgrading")
+}
+
+// TestArrowExporterDisableDowngrade tests that if the Recv() returns
+// any error downgrade still does not occur amd that the connection is
+// retried without error.
+func TestArrowExporterDisableDowngrade(t *testing.T) {
+	tc := newSingleStreamDowngradeDisabledTestCase(t)
+	badChannel := newArrowUnsupportedTestChannel()
+	goodChannel := newHealthyTestChannel()
+
+	fails := 0
+	tc.streamCall.AnyTimes().DoAndReturn(func(ctx context.Context, opts ...grpc.CallOption) (
+		arrowpb.ArrowStreamService_ArrowStreamClient,
+		error,
+	) {
+		defer func() { fails++ }()
+
+		if fails >= 3 {
+			return tc.returnNewStream(goodChannel)(ctx, opts...)
+		} else {
+			return tc.returnNewStream(badChannel)(ctx, opts...)
+		}
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		outputData := <-goodChannel.sent
+		goodChannel.recv <- statusOKFor(outputData.BatchId)
+	}()
+
+	bg := context.Background()
+	require.NoError(t, tc.exporter.Start(bg))
+
+	sent, err := tc.exporter.SendAndWait(bg, twoTraces)
+	require.True(t, sent)
+	require.NoError(t, err)
+
+	wg.Wait()
+
+	require.NoError(t, tc.exporter.Shutdown(bg))
+
+	require.Less(t, 1, len(tc.observedLogs.All()), "should have at least two logs: %v", tc.observedLogs.All())
+	require.Equal(t, tc.observedLogs.All()[0].Message, "arrow is not supported")
+	require.NotContains(t, tc.observedLogs.All()[1].Message, "downgrading")
 }
 
 // TestArrowExporterConnectTimeout tests that an error is returned to

--- a/exporter/otlpexporter/internal/arrow/exporter_test.go
+++ b/exporter/otlpexporter/internal/arrow/exporter_test.go
@@ -314,11 +314,10 @@ func TestArrowExporterDisableDowngrade(t *testing.T) {
 	) {
 		defer func() { fails++ }()
 
-		if fails >= 3 {
-			return tc.returnNewStream(goodChannel)(ctx, opts...)
-		} else {
+		if fails < 3 {
 			return tc.returnNewStream(badChannel)(ctx, opts...)
 		}
+		return tc.returnNewStream(goodChannel)(ctx, opts...)
 	})
 
 	var wg sync.WaitGroup

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -116,7 +116,7 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) (err erro
 			}
 		}
 
-		e.arrow = arrow.NewExporter(e.config.Arrow.NumStreams, e.settings.TelemetrySettings, e.callOptions, func() arrowRecord.ProducerAPI {
+		e.arrow = arrow.NewExporter(e.config.Arrow.NumStreams, e.config.Arrow.DisableDowngrade, e.settings.TelemetrySettings, e.callOptions, func() arrowRecord.ProducerAPI {
 			return arrowRecord.NewProducer()
 		}, arrowpb.NewArrowStreamServiceClient(e.clientConn), perRPCCreds)
 


### PR DESCRIPTION
**Description:** There are a few TODOs around making the downgrade feature more reliable. I notice that it is easy to get spurious downgrades when a host is not listening (intermittently) without setting `wait_for_ready`, [which may be a good default for OTLP-Arrow.](https://github.com/open-telemetry/experimental-arrow-collector/issues/40) 

Instead of waiting for refinements to the downgrade support, and for some initial production testing, I want to force Arrow mode by disabling downgrade. We can refine the downgrade feature with more care in the future.