### PR TITLE
Fix a race in otlpreceiver arrow test

### DIFF
--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -147,6 +147,8 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte) e
 		// Request is successful.
 		return nil
 	}
+	data, _ := io.ReadAll(resp.Body)
+	fmt.Println("RESPONSE", resp, string(data))
 
 	respStatus := readResponse(resp)
 

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -147,8 +147,6 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte) e
 		// Request is successful.
 		return nil
 	}
-	data, _ := io.ReadAll(resp.Body)
-	fmt.Println("RESPONSE", resp, string(data))
 
 	respStatus := readResponse(resp)
 

--- a/receiver/otlpreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otlpreceiver/internal/arrow/arrow_test.go
@@ -933,21 +933,23 @@ func testReceiverAuthHeaders(t *testing.T, includeMeta bool, dataAuth bool) {
 
 	var expectErrs []bool
 
-	for _, expect := range expectData {
+	for _, testInput := range expectData {
 		// The static stream context contains one extra variable.
-		if expect == nil {
-			expect = map[string][]string{}
+		cpy := map[string][]string{}
+		cpy["stream_ctx"] = []string{"per-request"}
+
+		for k, v := range testInput {
+			cpy[k] = v
 		}
-		expect["stream_ctx"] = []string{"per-request"}
 
 		expectErr := false
 		if dataAuth {
 			hasAuth := false
-			for _, val := range expect["auth"] {
+			for _, val := range cpy["auth"] {
 				hasAuth = hasAuth || (val == "true")
 			}
 			if hasAuth {
-				expect["has_auth"] = []string{":+1:", ":100:"}
+				cpy["has_auth"] = []string{":+1:", ":100:"}
 			} else {
 				expectErr = true
 			}
@@ -961,7 +963,7 @@ func testReceiverAuthHeaders(t *testing.T, includeMeta bool, dataAuth bool) {
 
 		info := client.FromContext((<-ctc.consume).Ctx)
 
-		for key, vals := range expect {
+		for key, vals := range cpy {
 			if includeMeta {
 				require.Equal(t, vals, info.Metadata.Get(key))
 			} else {


### PR DESCRIPTION
**Description:** Fixes a test-specific race condition.

As an action item, the CI/CD should run the race detector.