### PR TITLE
OTel-Arrow receiver: support AuthServer without IncludeMetadata

### DIFF
--- a/receiver/otlpreceiver/internal/arrow/arrow.go
+++ b/receiver/otlpreceiver/internal/arrow/arrow.go
@@ -17,6 +17,7 @@ package arrow // import "go.opentelemetry.io/collector/receiver/otlpreceiver/int
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	arrowpb "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
 	arrowRecord "github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
@@ -96,8 +97,15 @@ type headerReceiver struct {
 	// decoder maintains state across the stream.
 	decoder *hpack.Decoder
 
-	// client connection info from the stream context, to be extended
-	// with per-request metadata.
+	// includeMetadata as configured by gRPC settings.
+	includeMetadata bool
+
+	// hasAuthServer indicates that headers must be produced
+	// independent of includeMetadata.
+	hasAuthServer bool
+
+	// client connection info from the stream context, (optionally
+	// if includeMetadata) to be extended with per-request metadata.
 	connInfo client.Info
 
 	// streamHdrs was translated from the incoming context, will be
@@ -111,16 +119,19 @@ type headerReceiver struct {
 	tmpHdrs map[string][]string
 }
 
-func newHeaderReceiver(streamCtx context.Context, includeMetadata bool) *headerReceiver {
-	if !includeMetadata {
-		return nil
-	}
+func newHeaderReceiver(streamCtx context.Context, as auth.Server, includeMetadata bool) *headerReceiver {
 	hr := &headerReceiver{
-		connInfo: client.FromContext(streamCtx),
+		includeMetadata: includeMetadata,
+		hasAuthServer:   as != nil,
+		connInfo:        client.FromContext(streamCtx),
 	}
 
-	if smd, ok := metadata.FromIncomingContext(streamCtx); ok {
-		hr.streamHdrs = smd
+	// Note that we capture the incoming context if there is an
+	// Auth plugin configured or includeMetadata is set.
+	if hr.includeMetadata || hr.hasAuthServer {
+		if smd, ok := metadata.FromIncomingContext(streamCtx); ok {
+			hr.streamHdrs = smd
+		}
 	}
 
 	// Note the hpack decoder supports additional protections,
@@ -135,7 +146,7 @@ func newHeaderReceiver(streamCtx context.Context, includeMetadata bool) *headerR
 // client.Info with additional key:values associated with the arrow batch.
 // This is safe to call when h is nil.
 func (h *headerReceiver) combineHeaders(ctx context.Context, hdrsBytes []byte) (context.Context, map[string][]string, error) {
-	if h == nil || (len(hdrsBytes) == 0 && len(h.streamHdrs) == 0) {
+	if len(hdrsBytes) == 0 && len(h.streamHdrs) == 0 {
 		return ctx, nil, nil
 	}
 
@@ -143,27 +154,37 @@ func (h *headerReceiver) combineHeaders(ctx context.Context, hdrsBytes []byte) (
 		return h.newContext(ctx, h.streamHdrs), h.streamHdrs, nil
 	}
 
-	h.tmpHdrs = map[string][]string{}
+	// Note that we will parse the headers even if they are not
+	// used, to check for validity.  tmpHdrsAppend() will skip
+	// modifying tmpHdrs if it is nil.
+	h.tmpHdrs = nil
+
+	if h.includeMetadata || h.hasAuthServer {
+		h.tmpHdrs = map[string][]string{}
+	}
 
 	// Write calls the emitFunc, appending directly into `tmpHdrs`.
 	if _, err := h.decoder.Write(hdrsBytes); err != nil {
 		return ctx, nil, err
 	}
 
-	// Add streamHdrs that were not carried in the per-request headers.
-	for k, v := range h.streamHdrs {
-		// Note: This is done after the per-request metadata is defined
-		// in recognition of a potential for duplicated values stemming
-		// from the Arrow exporter's independent call to the Auth
-		// extension's GetRequestMetadata().  This paired with the
-		// headersetter's return of empty-string values means, we would
-		// end up with an empty-string element for any headersetter
-		// `from_context` rules b/c the stream uses background context.
-		// This allows static headers through.
-		//
-		// See https://github.com/open-telemetry/opentelemetry-collector/issues/6965
-		if _, ok := h.tmpHdrs[k]; !ok {
-			h.tmpHdrs[k] = v
+	if h.tmpHdrs != nil {
+		// Add streamHdrs that were not carried in the per-request headers.
+		for k, v := range h.streamHdrs {
+			// Note: This is done after the per-request metadata is defined
+			// in recognition of a potential for duplicated values stemming
+			// from the Arrow exporter's independent call to the Auth
+			// extension's GetRequestMetadata().  This paired with the
+			// headersetter's return of empty-string values means, we would
+			// end up with an empty-string element for any headersetter
+			// `from_context` rules b/c the stream uses background context.
+			// This allows static headers through.
+			//
+			// See https://github.com/open-telemetry/opentelemetry-collector/issues/6965
+			lk := strings.ToLower(k)
+			if _, ok := h.tmpHdrs[lk]; !ok {
+				h.tmpHdrs[lk] = v
+			}
 		}
 	}
 
@@ -171,28 +192,39 @@ func (h *headerReceiver) combineHeaders(ctx context.Context, hdrsBytes []byte) (
 	newHdrs := h.tmpHdrs
 	h.tmpHdrs = nil
 
+	// Note: newHdrs is passed to the Auth plugin.  Whether
+	// newHdrs is set in the context depends on h.includeMetadata.
 	return h.newContext(ctx, newHdrs), newHdrs, nil
 }
 
 // tmpHdrsAppend appends to tmpHdrs, from decoder's emit function.
 func (h *headerReceiver) tmpHdrsAppend(hf hpack.HeaderField) {
-	h.tmpHdrs[hf.Name] = append(h.tmpHdrs[hf.Name], hf.Value)
+	if h.tmpHdrs != nil {
+		// We force strings.ToLower to ensure consistency.  gRPC itself
+		// does this and would do the same.
+		hn := strings.ToLower(hf.Name)
+		h.tmpHdrs[hn] = append(h.tmpHdrs[hn], hf.Value)
+	}
 }
 
 func (h *headerReceiver) newContext(ctx context.Context, hdrs map[string][]string) context.Context {
 	// Retain the Addr/Auth of the stream connection, update the
 	// per-request metadata from the Arrow batch.
+	var md client.Metadata
+	if h.includeMetadata && hdrs != nil {
+		md = client.NewMetadata(hdrs)
+	}
 	return client.NewContext(ctx, client.Info{
 		Addr:     h.connInfo.Addr,
 		Auth:     h.connInfo.Auth,
-		Metadata: client.NewMetadata(hdrs),
+		Metadata: md,
 	})
 }
 
 func (r *Receiver) ArrowStream(serverStream arrowpb.ArrowStreamService_ArrowStreamServer) error {
 	streamCtx := serverStream.Context()
 	ac := r.newConsumer()
-	hrcv := newHeaderReceiver(serverStream.Context(), r.gsettings.IncludeMetadata)
+	hrcv := newHeaderReceiver(serverStream.Context(), r.authServer, r.gsettings.IncludeMetadata)
 
 	defer func() {
 		if err := ac.Close(); err != nil {

--- a/receiver/otlpreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otlpreceiver/internal/arrow/arrow_test.go
@@ -786,7 +786,7 @@ func TestHeaderReceiverRequestNoStreamMetadata(t *testing.T) {
 	}
 }
 
-func TestHeaderReceiverRequestAuthServerNoStreamMetadata(t *testing.T) {
+func TestHeaderReceiverAuthServerIsSetNoIncludeMetadata(t *testing.T) {
 	expect := map[string][]string{
 		"K": {"k1", "k2"},
 		"L": {"l1"},

--- a/receiver/otlpreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otlpreceiver/internal/arrow/arrow_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	arrowpb "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
@@ -691,7 +692,7 @@ func TestHeaderReceiverStreamContextOnly(t *testing.T) {
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD(expect))
 
-	h := newHeaderReceiver(ctx, true)
+	h := newHeaderReceiver(ctx, nil, true)
 
 	for i := 0; i < 3; i++ {
 		cc, _, err := h.combineHeaders(ctx, nil)
@@ -709,13 +710,45 @@ func TestHeaderReceiverNoIncludeMetadata(t *testing.T) {
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD(noExpect))
 
-	h := newHeaderReceiver(ctx, false)
+	h := newHeaderReceiver(ctx, nil, false)
 
 	for i := 0; i < 3; i++ {
 		cc, _, err := h.combineHeaders(ctx, nil)
 
 		require.NoError(t, err)
 		requireContainsNone(t, client.FromContext(cc).Metadata, noExpect)
+	}
+}
+
+func TestHeaderReceiverAuthServerNoIncludeMetadata(t *testing.T) {
+	expectForAuth := map[string][]string{
+		"L": {"k1", "k2"},
+		"K": {"l1"},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD(expectForAuth))
+
+	ctrl := gomock.NewController(t)
+	as := mock.NewMockServer(ctrl)
+
+	// The auth server is not called, it just needs to be non-nil.
+	as.EXPECT().Authenticate(gomock.Any(), gomock.Any()).Times(0)
+
+	h := newHeaderReceiver(ctx, as, false)
+
+	for i := 0; i < 3; i++ {
+		cc, hdrs, err := h.combineHeaders(ctx, nil)
+
+		// The incoming metadata keys are not in the context.
+		require.NoError(t, err)
+		requireContainsNone(t, client.FromContext(cc).Metadata, expectForAuth)
+
+		// Headers are returned for the auth server, though
+		// names have been forced to lower case.
+		require.Equal(t, len(hdrs), len(expectForAuth))
+		for k, v := range expectForAuth {
+			require.Equal(t, hdrs[strings.ToLower(k)], v)
+		}
 	}
 }
 
@@ -731,7 +764,7 @@ func TestHeaderReceiverRequestNoStreamMetadata(t *testing.T) {
 
 	ctx := context.Background()
 
-	h := newHeaderReceiver(ctx, true)
+	h := newHeaderReceiver(ctx, nil, true)
 
 	for i := 0; i < 3; i++ {
 		hpb.Reset()
@@ -739,7 +772,7 @@ func TestHeaderReceiverRequestNoStreamMetadata(t *testing.T) {
 		for key, vals := range expect {
 			for _, val := range vals {
 				err := hpe.WriteField(hpack.HeaderField{
-					Name:  key,
+					Name:  strings.ToLower(key),
 					Value: val,
 				})
 				require.NoError(t, err)
@@ -750,6 +783,63 @@ func TestHeaderReceiverRequestNoStreamMetadata(t *testing.T) {
 
 		require.NoError(t, err)
 		requireContainsAll(t, client.FromContext(cc).Metadata, expect)
+	}
+}
+
+func TestHeaderReceiverRequestAuthServerNoStreamMetadata(t *testing.T) {
+	expect := map[string][]string{
+		"K": {"k1", "k2"},
+		"L": {"l1"},
+	}
+
+	var hpb bytes.Buffer
+
+	hpe := hpack.NewEncoder(&hpb)
+
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	as := mock.NewMockServer(ctrl)
+
+	// The auth server is not called, it just needs to be non-nil.
+	as.EXPECT().Authenticate(gomock.Any(), gomock.Any()).Times(0)
+
+	h := newHeaderReceiver(ctx, as, true)
+
+	for i := 0; i < 3; i++ {
+		hpb.Reset()
+
+		for key, vals := range expect {
+			for _, val := range vals {
+				err := hpe.WriteField(hpack.HeaderField{
+					Name:  strings.ToLower(key),
+					Value: val,
+				})
+				require.NoError(t, err)
+			}
+		}
+
+		cc, hdrs, err := h.combineHeaders(ctx, hpb.Bytes())
+
+		require.NoError(t, err)
+
+		// Note: The call to client.Metadata.Get() inside
+		// requireContainsAll() actually modifies the metadata
+		// map (this is weird, but true and possibly
+		// valid). In cases where the input has incorrect
+		// case.  It's not safe to check that the map sizes
+		// are equal after calling Get() below, so we assert
+		// same size first.
+		require.Equal(t, len(hdrs), len(expect))
+
+		requireContainsAll(t, client.FromContext(cc).Metadata, expect)
+
+		// Headers passed to the auth server are equivalent w/
+		// with names forced to lower case.
+
+		for k, v := range expect {
+			require.Equal(t, hdrs[strings.ToLower(k)], v, "for %v", k)
+		}
 	}
 }
 
@@ -773,7 +863,7 @@ func TestHeaderReceiverBothMetadata(t *testing.T) {
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD(expectK))
 
-	h := newHeaderReceiver(ctx, true)
+	h := newHeaderReceiver(ctx, nil, true)
 
 	for i := 0; i < 3; i++ {
 		hpb.Reset()
@@ -781,7 +871,7 @@ func TestHeaderReceiverBothMetadata(t *testing.T) {
 		for key, vals := range expectL {
 			for _, val := range vals {
 				err := hpe.WriteField(hpack.HeaderField{
-					Name:  key,
+					Name:  strings.ToLower(key),
 					Value: val,
 				})
 				require.NoError(t, err)
@@ -819,7 +909,7 @@ func TestHeaderReceiverDuplicateMetadata(t *testing.T) {
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD(expectStream))
 
-	h := newHeaderReceiver(ctx, true)
+	h := newHeaderReceiver(ctx, nil, true)
 
 	for i := 0; i < 3; i++ {
 		hpb.Reset()
@@ -827,7 +917,7 @@ func TestHeaderReceiverDuplicateMetadata(t *testing.T) {
 		for key, vals := range expectRequest {
 			for _, val := range vals {
 				err := hpe.WriteField(hpack.HeaderField{
-					Name:  key,
+					Name:  strings.ToLower(key),
 					Value: val,
 				})
 				require.NoError(t, err)
@@ -916,7 +1006,7 @@ func testReceiverAuthHeaders(t *testing.T, includeMeta bool, dataAuth bool) {
 				for key, vals := range md {
 					for _, val := range vals {
 						err := hpe.WriteField(hpack.HeaderField{
-							Name:  key,
+							Name:  strings.ToLower(key),
 							Value: val,
 						})
 						require.NoError(t, err)


### PR DESCRIPTION
**Description:** 
Ensure the Auth Server implementation receives the complete set of headers, even when IncludeMetadata is not set. Prior to this fix, the AuthServer called per stream-data-item would only function when IncludeMetadata was set. IncludeMetadata determines what the pipeline sees, but the AuthServer should see the headers either way.

**Link to tracking Issue:** #45.
